### PR TITLE
run jenkins-cli as jenkins uses

### DIFF
--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -37,7 +37,7 @@ jenkins_install_plugin_{{ plugin }}:
     - unless: {{ jenkins_cli('list-plugins') }} | grep {{ plugin }}
     - name: {{ jenkins_cli('install-plugin', plugin) }}
     - timeout: 60
-    - user: jenkins
+    - user: {{ jenkins.user }}
     - require:
       - service: jenkins
       - cmd: jenkins_updates_file

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -37,6 +37,7 @@ jenkins_install_plugin_{{ plugin }}:
     - unless: {{ jenkins_cli('list-plugins') }} | grep {{ plugin }}
     - name: {{ jenkins_cli('install-plugin', plugin) }}
     - timeout: 60
+    - user: jenkins
     - require:
       - service: jenkins
       - cmd: jenkins_updates_file


### PR DESCRIPTION
does not need to run as root and particular to search for ssh private key.